### PR TITLE
Return full complement of Moz metrics fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,13 +14,60 @@ var (
 	defaultMaxBatchURLs = 10
 )
 
+// SpamScore represents the spam score for a subdomain
+// the fields of which are described at https://moz.com/help/guides/moz-api/mozscape/getting-started-with-mozscape/spam-score
+// This will eventually, according to moz at least, be replaces with the same 0-100 score the browser shows.
+// Until then, SpamScore is an empty interface. Partially because the columns it describes aren't documented, and also
+// to allow for type switches to provide some backwards compatability in code for when Moz change their API
+type SpamScore interface{}
+
 // URLMetrics is the basic structure returned by the API
 type URLMetrics struct {
-	PageAuthority      float64 `json:"upa"`
-	DomainAuthority    float64 `json:"pda"`
-	Links              float64 `json:"uid"`
-	RootDomainsLinking float64 `json:"uipl"`
-	URL                string  `json:"uu"`
+	Title                                     string    `json:"ut"`
+	URL                                       string    `json:"uu"`
+	Subdomain                                 string    `json:"ufq"`
+	RootDomain                                string    `json:"upl"`
+	ExternalEquityLinks                       float64   `json:"ueid"`
+	SubdomainExternalLinks                    float64   `json:"feid"`
+	RootDomainExternalLinks                   float64   `json:"peid"`
+	EquityLinksSubdomains                     float64   `json:"ujid"`
+	SubdomainsLinking                         float64   `json:"uifq"`
+	RootDomainsLinking                        float64   `json:"uipl"`
+	Links                                     float64   `json:"uid"`
+	SubdomainSubdomainsLinking                float64   `json:"fid"`
+	RootDomainRootDomainsLinking              float64   `json:"pid"`
+	MozRankURLNormalized                      float64   `json:"umrp"`
+	MozRankURLRaw                             float64   `json:"umrr"`
+	MozRankSubdomainNormalized                float64   `json:"fmrp"`
+	MozRankSubdomainRaw                       float64   `json:"fmrr"`
+	MozTrustNormalized                        float64   `json:"utrp"`
+	MozTrustRaw                               float64   `json:"utrr"`
+	MozTrustSubdomainNormalized               float64   `json:"ftrp"`
+	MozTrustSubdomainRaw                      float64   `json:"ftrr"`
+	MozTrustDomainNormalized                  float64   `json:"ptrp"`
+	MozTrustDomainRaw                         float64   `json:"ptrr"`
+	MozRankExternalEquityNormalized           float64   `json:"uemrp"`
+	MozRankExternalEquityRaw                  float64   `json:"uemrr"`
+	MozRankSubdomainExternalEquityNormalized  float64   `json:"fejp"`
+	MozRankSubdomainExternalEquityRaw         float64   `json:"fejr"`
+	MozRankRootDomainExternalEquityNormalized float64   `json:"pejp"`
+	MozRankRootDomainExternalEquityRaw        float64   `json:"pejr"`
+	MozRankSubdomainCombinedNormalized        float64   `json:"pjp"`
+	MozRankSubdomainCombinedRaw               float64   `json:"pjr"`
+	MozRankRootDomainCombinedNormalized       float64   `json:"fjp"`
+	MozRankRootDomainCombinedRaw              float64   `json:"fjr"`
+	SubdomainSpamScore                        SpamScore `json:"fspsc"`
+	HTTPStatusCode                            float64   `json:"us"`
+	LinksToSubdomain                          float64   `json:"fuid"`
+	LinksToRootDomain                         float64   `json:"puid"`
+	RootDomainsLinkingToSubdomain             float64   `json:"fipl"`
+	PageAuthority                             float64   `json:"upa"`
+	DomainAuthority                           float64   `json:"pda"`
+	ExternalLinks                             float64   `json:"ued"`
+	ExternalLinksToSubdomain                  float64   `json:"fed"`
+	ExternalLinksToRootDomain                 float64   `json:"ped"`
+	LinkingCBlocks                            float64   `json:"pid"`
+	LastCrawlTime                             int64     `json:"ulc"`
 }
 
 type mozAPI interface {


### PR DESCRIPTION
When @btp9 and I came to use this package yesterday we found some of the fields we required weren't exposed.

This PR includes all fields in the `URLMetrics` type.

I have purposefully kept to using `float64` for scores and counts, despite some being returned as `int`s, I figure there's a point they're originally `float64` which isn't documented.

Because of Moz's love of undocumented changes, `SpamScore` is an `interface{}`- for now it returns _n_ columns of indeterminate/ undocumented types, but this will change eventually to be the 0..100 score we all know (?) and love (?)